### PR TITLE
Refactor GoogleBookService for detailed book data

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ The template is a string that contains various keys enclosed in double curly bra
 
 You can use `\n` to insert a line break in the template. For example, the following template:
 
+> **Note:** If you edit the content directly in the `settings.json` file of the Logseq plugin configurations, you should use `\\n` for line breaks. However, if you edit it through the Logseq app, you only need to use `\n`.
+
 ## Examples
 
 Here are some examples of how you can use the template configuration:
@@ -89,6 +91,8 @@ Here are some examples of how you can use the template configuration:
 ```
 - Title: {{title}}\n- Authors: {{authors}}\n- ISBN: {{isbn}}\n- Published At: {{publishedAt}}\n- Categories: {{categories}}\n- Pages: {{pages}}\n- Language: {{language}}\n- Publisher: {{publisher}}\n- Maturity Rating: {{maturityRating}}\n- Description: {{description}}
 ```
+
+> **Note:** If you edit the content directly in the `settings.json` file of the Logseq plugin configurations, you should use `\\n` for line breaks. However, if you edit it through the Logseq app, you only need to use `\n`.
 
 ![Example 2](docs/images/output-2.gif)
 

--- a/src/services/GoogleBookService.ts
+++ b/src/services/GoogleBookService.ts
@@ -1,5 +1,5 @@
 import { Book } from '../enities/Book';
-import { GoogleBookResponse } from '../enities/GoogleBook';
+import { GoogleBookResponse, Item } from '../enities/GoogleBook';
 import { IBookService } from './IBookService';
 
 export class GoogleBookService implements IBookService {
@@ -13,11 +13,14 @@ export class GoogleBookService implements IBookService {
   async getBook(isbn: string): Promise<Book | null> {
     const url = `${this.baseUrl}?q=isbn:${isbn}`;
     const response = await fetch(url);
-    const data: GoogleBookResponse = await response.json();
-    if (data.totalItems === 0) {
+    const resultSearch: GoogleBookResponse = await response.json();
+    if (resultSearch.totalItems === 0) {
       return null;
     }
-    const book = data.items[0].volumeInfo;
+    const urlBook = `${this.baseUrl}/${resultSearch.items[0].id}`;
+    const responseBook = await fetch(urlBook);
+    const data: Item = await responseBook.json();
+    const book = data.volumeInfo;
     return {
       isbn,
       title: book.title,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -7,7 +7,7 @@ export const settings: SettingSchemaDesc[] = [
       'The template to use when fetching a book. Use the following variables: title, isbn, authors, publishedAt, categories, pages, language, publisher, maturityRating, description, thumbnail',
     type: 'string',
     default:
-      '- ![Book Cover]({{thumbnail}})\n- Title: {{title}}\n- ISBN: {{isbn}}\n- Authors: {{authors}}\n- Published At: {{publishedAt}}\n- Categories: {{categories}}\n- Pages: {{pages}}\n- Language: {{language}}\n- Publisher: {{publisher}}\n- Maturity Rating: {{maturityRating}}\n- Description: {{description}}',
+      '- ![Book Cover]({{thumbnail}})\\n- Title: {{title}}\\n- ISBN: {{isbn}}\\n- Authors: {{authors}}\\n- Published At: {{publishedAt}}\\n- Categories: {{categories}}\\n- Pages: {{pages}}\\n- Language: {{language}}\\n- Publisher: {{publisher}}\\n- Maturity Rating: {{maturityRating}}\\n- Description: {{description}}',
     title: 'Template',
   },
 ];


### PR DESCRIPTION
The GoogleBookService has been refactored to fetch more detailed information about a book. Previously, the service was only fetching basic details from the initial search result. Now, it makes an additional request using the ID of the first search result to retrieve comprehensive data about the book. This includes changes in variable naming for clarity and importing 'Item' from 'GoogleBook'.